### PR TITLE
Add intermediate proxy for submitting to Trello

### DIFF
--- a/Trello_Reporting_Tool.gd
+++ b/Trello_Reporting_Tool.gd
@@ -45,7 +45,7 @@ func _ready():
 		$Content/Form/Custom/Type.selected = 0
 	else:
 		$Content/Form/Custom/Type.hide()
-		
+
 	# call this to show and reset the window
 	show_window()
 
@@ -169,8 +169,12 @@ func create_card():
 		var type = $Content/Form/Custom/Type.selected
 		data['label_id'] = trello_labels[type].label_trello_id
 
-	# the cover attachment must be an image. If you don't want so sent further attachments, just leave attachments empty.
-	# Use the function 'from_path' to attach files from the filesystem or 'from_image' to convert an Image class variable to a file.
+	# The cover attachment must be an image. If you don't want so sent further
+	# attachments, just leave attachments empty.
+	#
+	# Use the function Attachment.from_path() to attach files from the
+	# filesystem or Attachment.from_image() to convert an Image instance to a
+	# file.
 	data['cover'] = Attachment.from_path("res://icon.png")
 	data['attachments'] = [
 		Attachment.from_image(
@@ -255,7 +259,6 @@ func create_card():
 		return
 
 	change_feedback("Feedback sent successfully, thank you!")
-	
 
 func show_feedback():
 	#disable all input fields and show a short message about the current status
@@ -263,7 +266,7 @@ func show_feedback():
 	$Content/Feedback.show()
 	change_feedback("Your feedback is being sent...", true)
 
-func change_feedback( new_message : String, close_button_disabled := false ) -> void:
+func change_feedback(new_message: String, close_button_disabled: bool = false) -> void:
 	feedback.text = new_message
 	close_button.disabled = close_button_disabled
 	close_button.text = "Please wait" if close_button_disabled else "Close"

--- a/Trello_Reporting_Tool.gd
+++ b/Trello_Reporting_Tool.gd
@@ -5,8 +5,11 @@ extends Panel
 const PROXY_HOST = 'proxy.example'
 const PROXY_PATH = '/proxy.php'
 
-# if you don't want to use labels, just leave this dictionary empty, you can add as many labels as you need by just expanding the library
-# to find out the label ids, use the same way as with the list ids. look for the label ids in the Trello json.
+# If you don't want to use labels, just leave this dictionary empty, you can
+# add as many labels as you need by just expanding the library.
+#
+# To find out the label ids, use the same way as with the list ids. look for
+# the label ids in the Trello json.
 var trello_labels = {
 	0 : {
 		"label_trello_id"	: "LABEL ID FROM TRELLO",
@@ -94,8 +97,10 @@ func create_card():
 
 	var timeout = 30.0
 	timer.start()
-	while http.get_status() == HTTPClient.STATUS_CONNECTING or \
-		  http.get_status() == HTTPClient.STATUS_RESOLVING:
+	while http.get_status() in [
+		HTTPClient.STATUS_CONNECTING,
+		HTTPClient.STATUS_RESOLVING
+	]:
 		http.poll()
 		yield(timer, 'timeout')
 		timeout -= timer.get_wait_time()
@@ -125,8 +130,10 @@ func create_card():
 			return
 	timer.stop()
 
-	if http.get_status() != HTTPClient.STATUS_BODY and \
-	   http.get_status() != HTTPClient.STATUS_CONNECTED:
+	if not http.get_status() in [
+		HTTPClient.STATUS_BODY,
+		HTTPClient.STATUS_CONNECTED
+	]:
 		feedback.text = "Unable to connect to server :-("
 		return
 

--- a/Trello_Reporting_Tool.gd
+++ b/Trello_Reporting_Tool.gd
@@ -2,21 +2,13 @@ extends Panel
 
 # Trello Reporting Tool - by Raffaele Picca: twitter.com/MV_Raffa
 
-# You need to get a key and generate a token by visiting this website (And you need to be logged in with the correct account):
-# https://trello.com/app-key
-var trello_key := "YOUR TRELLO API KEY"
-var trello_token := "YOUR TRELLO API TOKEN"
-var key_and_token = "?key=" + trello_key + "&token=" + trello_token
-
-# to find the trello list id, the easiest way is to look up your Trello board, create the list you want to use, add a card, 
-# click on the card and add ".json" to the url in the top
-# you can then search for idList" - string behind that is the list_id below.
-var list_id := "YOUR TRELLO LIST ID"
+const PROXY_HOST = 'proxy.example'
+const PROXY_PATH = '/proxy.php'
 
 # if you don't want to use labels, just leave this dictionary empty, you can add as many labels as you need by just expanding the library
 # to find out the label ids, use the same way as with the list ids. look for the label ids in the Trello json.
 var trello_labels = {
-	0 : { 
+	0 : {
 		"label_trello_id"	: "LABEL ID FROM TRELLO",
 		"label_description"	: "Label name for Option Button"
 	},
@@ -26,19 +18,16 @@ var trello_labels = {
 	}
 }
 
-var current_card_hash := 0
-var current_card_id := ""
-
+onready var timer = Timer.new()
 onready var http = HTTPClient.new()
-onready var http_req = $HTTPRequest
 onready var short_text = $VBoxContainer/HBoxContainer/ShortDescEdit
 onready var long_text = $VBoxContainer/HBoxContainer/LongDescEdit
 onready var send_button = $VBoxContainer/HBoxContainer/Custom/Send
-
-enum tasks {IDLE, CREATE_CARD, GET_CARD_ID, ADD_LABEL}
-var task = tasks.IDLE
+onready var feedback = $VBoxContainer/HBoxContainer/Custom/feedback
 
 func _ready():
+	timer.set_wait_time(0.2)
+	add_child(timer)
 	if !trello_labels.empty():
 		for i in range(trello_labels.size()):
 			$VBoxContainer/HBoxContainer/Custom/Type.add_item(trello_labels[i].label_description, i)
@@ -46,104 +35,97 @@ func _ready():
 	else:
 		$VBoxContainer/HBoxContainer/Custom/Type.hide()
 
-func _on_HTTPRequest_request_completed(_result, response_code, _headers, body):
-	if task == tasks.CREATE_CARD:
-		print_debug("CREATE_CARD -> " + str(response_code))
-		get_card_id()
-		return
-	
-	elif task == tasks.GET_CARD_ID and current_card_id == "":
-		print_debug("GET_CARD_ID -> " + str(response_code))
-		var dict_result = parse_json(body.get_string_from_utf8())
-		for i in dict_result:
-			if str(current_card_hash) in i.name:
-				current_card_id = i.id
-				if !trello_labels.empty():
-					add_label_to_card()
-				add_attachment()
-				return
-	
-	elif task == tasks.ADD_LABEL:
-		print_debug("ADD_LABEL -> " + str(response_code))
-
 func _on_Send_pressed():
-	create_card()
 	show_feedback()
 	send_button.disabled = true
+	create_card()
 
-func get_card_id():
-	task = tasks.GET_CARD_ID
-	var query = "https://api.trello.com/1/lists/"+list_id+"/cards" + key_and_token
-	http_req.request(query, [], true, HTTPClient.METHOD_GET)
+func send_post(http: HTTPClient, path: String, data: Dictionary) -> int:
+	var boundary: String = 'GodotFileUploadBoundaryZ29kb3RmaWxl'
+	var headers = ['Content-Type: multipart/form-data; boundary=' + boundary]
+
+	var body: PoolByteArray
+	for key in data:
+		var value = data[key]
+		var extra: String = ''
+		var bytes: PoolByteArray
+
+		if value is File:
+			var fname = value.get_path().get_file()
+			var mimetype: String
+			match value.get_path().get_extension():
+				'png':
+					mimetype = 'image/png'
+				'jpg', 'jpeg':
+					mimetype = 'image/jpeg'
+				'gif':
+					mimetype = 'image/gif'
+				_:
+					continue
+			extra = '; filename="' + fname + '"\r\nContent-Type: ' + mimetype
+			bytes = value.get_buffer(value.get_len())
+		else:
+			bytes = value.to_ascii()
+
+		var buf = 'Content-Disposition: form-data; name="' + key + '"' + extra
+		body += ('--' + boundary + '\r\n' + buf + '\r\n\r\n').to_ascii()
+		body += bytes + '\r\n'.to_ascii()
+
+	body += ('--' + boundary + '--\r\n').to_ascii()
+
+	return http.request_raw(HTTPClient.METHOD_POST, path, headers, body)
 
 func create_card():
-	task = tasks.CREATE_CARD
-	
-	current_card_hash = str(str(OS.get_unique_id()) + str(OS.get_ticks_msec()) + str(OS.get_datetime()) ).hash()
-	var current_card_title = str( short_text.text + " [" + str( current_card_hash ) + "]")
-	var current_card_desc = long_text.text
-	current_card_desc += "\n\n**Operating System:** " + OS.get_name()
-	
-	var query = "https://api.trello.com/1/cards" + key_and_token
-	query += "&idList=" + list_id
-	query += "&name=" + current_card_title.percent_encode()
-	query += "&desc=" + current_card_desc.percent_encode()
-	query += "&pos=top"
-	
-	http_req.request(query, [], true, HTTPClient.METHOD_POST)
+	var data = {
+		'name': short_text.text,
+		'desc': long_text.text + "\n\n**Operating System:** " + OS.get_name(),
+	}
 
-func add_label_to_card():
-	task = tasks.ADD_LABEL
-	var type = $VBoxContainer/HBoxContainer/Custom/Type.selected
-	var query = "https://api.trello.com/1/cards/"+current_card_id+"/idLabels" + key_and_token + "&value=" + trello_labels[type].label_trello_id
-	http_req.request(query, [], true, HTTPClient.METHOD_POST)
+	if !trello_labels.empty():
+		var type = $VBoxContainer/HBoxContainer/Custom/Type.selected
+		data['label_id'] = trello_labels[type].label_trello_id
 
-func attachment_get_body():
-	# The default icon.png is attached, you can attach any file, just change the Content-Type in the body part below to match the file type:
-	# https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-	var file = File.new()
-	file.open("res://icon.png", File.READ)
-	var file_content = file.get_buffer(file.get_len())
-	file.close()
-	
-	
-	# create the body of the multipart/form-data , change the "Content-Type" if you want to send something else than an image.
-	var boundary_start = "--GodotFileUploadBoundaryZ29kb3RmaWxl\r\n".to_ascii()
-	var body = boundary_start
-	body += ("Content-Disposition: form-data; name=\"key\"\r\n\r\n" + trello_key + "\r\n").to_ascii()
-	body += boundary_start
-	body += ("Content-Disposition: form-data; name=\"token\"\r\n\r\n" + trello_token + "\r\n").to_ascii()
-	body += boundary_start
-	body += ("Content-Disposition: form-data; name=\"name\"\r\n\r\nImage-"+str(current_card_hash)+"\r\n").to_ascii()
-	body += boundary_start
-	body += ("Content-Disposition: form-data; name=\"setCover\"\r\n\r\ntrue\r\n").to_ascii()
-	body += boundary_start
-	body += ("Content-Disposition: form-data; name=\"file\"; filename=\"Image_"+str(current_card_hash)+".png\"\r\nContent-Type: image/png\r\n\r\n").to_ascii()
-	body += file_content
-	body += ("\r\n--GodotFileUploadBoundaryZ29kb3RmaWxl--\r\n").to_ascii()
-	
-	return body
+	var attachment = File.new()
+	attachment.open("res://icon.png", File.READ)
+	data['attachment'] = attachment
+	data['cover_file'] = 'attachment'
 
-func add_attachment():
-	# setup the header for sending attachments via multipart
-	var headers = ["Content-Type: multipart/form-data; boundary=GodotFileUploadBoundaryZ29kb3RmaWxl"]
-	var path = "/1/cards/"+ current_card_id +"/attachments"
-	
-	http.connect_to_host("https://api.trello.com", -1, true, false)
+	http.connect_to_host(PROXY_HOST, -1, true)
 
-	while http.get_status() == HTTPClient.STATUS_CONNECTING or http.get_status() == HTTPClient.STATUS_RESOLVING:
+	var timeout = 30.0
+	timer.start()
+	while http.get_status() == HTTPClient.STATUS_CONNECTING or \
+		  http.get_status() == HTTPClient.STATUS_RESOLVING:
 		http.poll()
-		OS.delay_msec(50)
-	
-	var err = http.request_raw(HTTPClient.METHOD_POST, path, headers, attachment_get_body())
-	
+		yield(timer, 'timeout')
+		timeout -= timer.get_wait_time()
+		if timeout < 0.0:
+			feedback.text = "Timeout while waiting to connect to server :-("
+			timer.stop()
+			return
+	timer.stop()
+
+	if http.get_status() != HTTPClient.STATUS_CONNECTED:
+		feedback.text = "Unable to connect to server :-("
+		return
+
+	if send_post(http, PROXY_PATH, data) != OK:
+		feedback.text = "Unable to send feedback to server :-("
+		return
+
+	timeout = 30.0
+	timer.start()
 	while http.get_status() == HTTPClient.STATUS_REQUESTING:
 		http.poll()
-		if not OS.has_feature("web"):
-			OS.delay_msec(50)
-		else:
-			yield(Engine.get_main_loop(), "idle_frame")
-	$VBoxContainer/HBoxContainer/Custom/feedback.text = "Feedback sent successfully, thank you!"
+		yield(timer, 'timeout')
+		timeout -= timer.get_wait_time()
+		if timeout < 0.0:
+			feedback.text = "Timeout waiting for server acknowledgement :-("
+			timer.stop()
+			return
+	timer.stop()
+
+	feedback.text = "Feedback sent successfully, thank you!"
 
 func show_feedback():
 	#disable all input fields and show a short message about the current status
@@ -151,8 +133,8 @@ func show_feedback():
 	short_text.editable = false
 	long_text.readonly = true
 	$VBoxContainer/HBoxContainer/Custom/Type.hide()
-	$VBoxContainer/HBoxContainer/Custom/feedback.show()
-	$VBoxContainer/HBoxContainer/Custom/feedback.text = "Your feedback is being sent..."
+	feedback.show()
+	feedback.text = "Your feedback is being sent..."
 
 func _on_ShortDescEdit_text_changed(_new_text):
 	update_send_button()

--- a/Trello_Reporting_Tool.gd
+++ b/Trello_Reporting_Tool.gd
@@ -115,7 +115,7 @@ func create_post_data(key: String, value) -> PoolByteArray:
 			extra += '\r\nContent-Type: ' + value.mimetype
 		bytes = value.data
 	elif value != null:
-		bytes = value.to_ascii()
+		bytes = value.to_utf8()
 
 	var buf = 'Content-Disposition: form-data; name="' + key + '"' + extra
 	body += ('--' + POST_BOUNDARY + '\r\n' + buf + '\r\n\r\n').to_ascii()

--- a/Trello_Reporting_Tool.tscn
+++ b/Trello_Reporting_Tool.tscn
@@ -17,9 +17,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="TimeoutTimer" type="Timer" parent="."]
+wait_time = 0.2
+
 [node name="HTTPRequest" type="HTTPRequest" parent="."]
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="Content" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 margin_left = 10.0
 margin_top = 10.0
@@ -32,87 +35,76 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Label" type="Label" parent="VBoxContainer"]
+[node name="Label" type="Label" parent="Content"]
 margin_right = 280.0
 margin_bottom = 14.0
 text = "Trello Reporting Tool"
 align = 1
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="HSeparator" type="HSeparator" parent="Content"]
 margin_top = 14.0
 margin_right = 280.0
 margin_bottom = 18.0
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Content"]
 margin_top = 18.0
 margin_right = 280.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 0, 10 )
 
-[node name="HBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+[node name="Form" type="VBoxContainer" parent="Content"]
 margin_top = 28.0
 margin_right = 280.0
 margin_bottom = 235.0
 custom_constants/separation = 0
 
-[node name="ShortDescLabel" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="ShortDescLabel" type="Label" parent="Content/Form"]
 margin_right = 280.0
 margin_bottom = 14.0
 text = "Title"
 
-[node name="ShortDescEdit" type="LineEdit" parent="VBoxContainer/HBoxContainer"]
+[node name="ShortDescEdit" type="LineEdit" parent="Content/Form"]
 margin_top = 14.0
 margin_right = 280.0
 margin_bottom = 38.0
 
-[node name="Spacer" type="MarginContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="Spacer" type="MarginContainer" parent="Content/Form"]
 margin_top = 38.0
 margin_right = 280.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 0, 10 )
 
-[node name="LongDescLabel" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="LongDescLabel" type="Label" parent="Content/Form"]
 margin_top = 48.0
 margin_right = 280.0
 margin_bottom = 62.0
 text = "Description"
 
-[node name="LongDescEdit" type="TextEdit" parent="VBoxContainer/HBoxContainer"]
+[node name="LongDescEdit" type="TextEdit" parent="Content/Form"]
 margin_top = 62.0
 margin_right = 280.0
 margin_bottom = 167.0
 rect_min_size = Vector2( 0, 105 )
 size_flags_vertical = 3
 
-[node name="Spacer2" type="MarginContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="Spacer2" type="MarginContainer" parent="Content/Form"]
 margin_top = 167.0
 margin_right = 280.0
 margin_bottom = 187.0
 rect_min_size = Vector2( 0, 20 )
 
-[node name="Custom" type="HBoxContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="Custom" type="HBoxContainer" parent="Content/Form"]
 margin_top = 187.0
 margin_right = 280.0
 margin_bottom = 207.0
 
-[node name="feedback" type="Label" parent="VBoxContainer/HBoxContainer/Custom"]
-visible = false
-margin_right = 285.0
-margin_bottom = 14.0
-size_flags_horizontal = 3
-text = "report"
-align = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Type" type="OptionButton" parent="VBoxContainer/HBoxContainer/Custom"]
+[node name="Type" type="OptionButton" parent="Content/Form/Custom"]
 margin_right = 138.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 pressed = true
 
-[node name="Send" type="Button" parent="VBoxContainer/HBoxContainer/Custom"]
+[node name="Send" type="Button" parent="Content/Form/Custom"]
 margin_left = 142.0
 margin_right = 280.0
 margin_bottom = 20.0
@@ -122,7 +114,42 @@ text = "Send"
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Feedback" type="VBoxContainer" parent="Content"]
+visible = false
+margin_top = 235.0
+margin_right = 280.0
+margin_bottom = 347.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MarginContainer" type="MarginContainer" parent="Content/Feedback"]
+margin_right = 280.0
+margin_bottom = 70.0
+rect_min_size = Vector2( 0, 70 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="feedback_label" type="Label" parent="Content/Feedback"]
+margin_top = 74.0
+margin_right = 280.0
+margin_bottom = 88.0
+size_flags_horizontal = 3
+text = "report"
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="close_button" type="Button" parent="Content/Feedback"]
+margin_top = 92.0
+margin_right = 280.0
+margin_bottom = 112.0
+text = "Processing..."
 [connection signal="request_completed" from="HTTPRequest" to="." method="_on_HTTPRequest_request_completed"]
-[connection signal="text_changed" from="VBoxContainer/HBoxContainer/ShortDescEdit" to="." method="_on_ShortDescEdit_text_changed"]
-[connection signal="text_changed" from="VBoxContainer/HBoxContainer/LongDescEdit" to="." method="_on_LongDescEdit_text_changed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/Custom/Send" to="." method="_on_Send_pressed"]
+[connection signal="text_changed" from="Content/Form/ShortDescEdit" to="." method="_on_ShortDescEdit_text_changed"]
+[connection signal="text_changed" from="Content/Form/LongDescEdit" to="." method="_on_LongDescEdit_text_changed"]
+[connection signal="pressed" from="Content/Form/Custom/Send" to="." method="_on_Send_pressed"]
+[connection signal="pressed" from="Content/Feedback/close_button" to="." method="_on_close_button_pressed"]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1602171281,
+        "narHash": "sha256-yMTXINoCp6cDY4jVhrZeko34a5upzXfPyOiQeMPkI4o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c9ffeeda141636e96c33aadbefa30c7c3ac681a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,17 @@
           ${lib.escapeShellArg "${self}/Trello_Reporting_Tool.tscn"} \
           "$@"
       '';
+
+      godot-trello-proxy = pkgs.writeScriptBin "godot-trello-proxy" ''
+        #!${pkgs.stdenv.shell}
+        exec ${pkgs.php}/bin/php \
+          -d error_reporting=E_ALL \
+          -d display_errors=Off \
+          -d log_errors=On \
+          -S 127.0.0.1:3333 \
+          -t ${lib.escapeShellArg self} \
+          "$@"
+      '';
     });
 
     checks = lib.genAttrs systems (system: let
@@ -259,7 +270,11 @@
     devShell = lib.genAttrs systems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in pkgs.mkShell {
-      nativeBuildInputs = [ pkgs.godot self.packages.${system}.godot-gut ];
+      nativeBuildInputs = [
+        pkgs.godot
+        self.packages.${system}.godot-gut
+        self.packages.${system}.godot-trello-proxy
+      ];
     });
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -85,14 +85,14 @@
       godot-gut = mkGodotGut false;
       godot-gut-headless = mkGodotGut true;
 
-      godot-trello-reporting = pkgs.writeScriptBin "godot-trello-reporting" ''
+      trello-reporting = pkgs.writeScriptBin "godot-trello-reporting" ''
         #!${pkgs.stdenv.shell}
         exec ${pkgs.godot}/bin/godot \
           ${lib.escapeShellArg "${self}/Trello_Reporting_Tool.tscn"} \
           "$@"
       '';
 
-      godot-trello-proxy = pkgs.writeScriptBin "godot-trello-proxy" ''
+      proxy = pkgs.writeScriptBin "godot-trello-proxy" ''
         #!${pkgs.stdenv.shell}
         exec ${pkgs.php}/bin/php \
           -d error_reporting=E_ALL \
@@ -264,7 +264,7 @@
     });
 
     defaultPackage = let
-      getPackage = system: self.packages.${system}.godot-trello-reporting;
+      getPackage = system: self.packages.${system}.trello-reporting;
     in lib.genAttrs systems getPackage;
 
     devShell = lib.genAttrs systems (system: let
@@ -273,7 +273,7 @@
       nativeBuildInputs = [
         pkgs.godot
         self.packages.${system}.godot-gut
-        self.packages.${system}.godot-trello-proxy
+        self.packages.${system}.proxy
       ];
     });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,19 @@
             enableACME = false;
             sslServerCert = "${certs.proxy}/cert.pem";
             sslServerKey = "${certs.proxy}/key.pem";
-            documentRoot = self;
+            documentRoot = pkgs.runCommand "docroot" {
+              src = "${self}/proxy.php";
+              YOUR_TRELLO_API_KEY = "6686ab7c98c9478a858c7509cce4e567";
+              YOUR_TRELLO_API_TOKEN = "903a96bcb0f2457986ed6f4e4d4d5016"
+                                    + "04ea488a45034e57aea56a16ed59528a";
+              YOUR_TRELLO_LIST_ID = "44b3a1b2db65488e8ba5a9dfba1dd9aa";
+            } ''
+              mkdir "$out"
+              substitute "$src" "$out/proxy.php" \
+                --subst-var YOUR_TRELLO_API_KEY \
+                --subst-var YOUR_TRELLO_API_TOKEN \
+                --subst-var YOUR_TRELLO_LIST_ID
+            '';
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -184,7 +184,7 @@
               YOUR_TRELLO_API_KEY = "6686ab7c98c9478a858c7509cce4e567";
               YOUR_TRELLO_API_TOKEN = "903a96bcb0f2457986ed6f4e4d4d5016"
                                     + "04ea488a45034e57aea56a16ed59528a";
-              YOUR_TRELLO_LIST_ID = "44b3a1b2db65488e8ba5a9dfba1dd9aa";
+              YOUR_TRELLO_LIST_ID = "44b3a1b2db65488e8ba5a9df";
             } ''
               mkdir "$out"
               substitute "$src" "$out/proxy.php" \

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
         -out "$out/cert.pem" -days 36500
       '';
 
-      certs.proxy = mkSnakeoilCert "proxy.test";
+      certs.proxy = mkSnakeoilCert "proxy.example";
       certs.trello = mkSnakeoilCert "api.trello.com";
 
       commonConfig = { config, nodes, ... }: {
@@ -162,8 +162,8 @@
           imports = [ commonConfig ];
           services.httpd.enable = true;
           services.httpd.enablePHP = true;
-          services.httpd.adminAddr = "admin@proxy.test";
-          services.httpd.virtualHosts."proxy.test" = {
+          services.httpd.adminAddr = "admin@proxy.example";
+          services.httpd.virtualHosts."proxy.example" = {
             forceSSL = true;
             enableACME = false;
             sslServerCert = "${certs.proxy}/cert.pem";
@@ -244,7 +244,7 @@
           proxy.wait_for_open_port(443)
           client.wait_for_x()
 
-          client.succeed('ping -c1 proxy.test >&2')
+          client.succeed('ping -c1 proxy.example >&2')
           proxy.succeed('ping -c1 api.trello.com >&2')
 
           client.succeed('test-runner >&2')

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,132 @@
+{
+  description = "Godot - Trello Reporting Tool";
+
+  outputs = { self, nixpkgs }: let
+    inherit (nixpkgs) lib;
+    systems = [ "x86_64-linux" ];
+  in {
+    packages = lib.genAttrs systems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      mkGodotGut = isHeadless: let
+        godot = if isHeadless then pkgs.godot-headless else pkgs.godot;
+        godotCmd = if isHeadless then "godot-headless" else "godot";
+
+        gutSrc = pkgs.stdenv.mkDerivation {
+          pname = "gut";
+          version = "7.0.0";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "bitwes";
+            repo = "Gut";
+            rev = "v7.0.0";
+            sha256 = "0zjz33hxay2w3qbgv7x24izcm93bj0f6x4mayxzz10kl0aa6w9rq";
+          };
+
+          postPatch = ''
+            sed -i -e 's!res://addons/gut/fonts!'"$out/addons/gut/fonts"'!' \
+              addons/gut/GutScene.gd
+          '';
+
+          installPhase = "cp -r . \"$out\"";
+        };
+
+        godotGut = godot.overrideAttrs (drv: {
+          inherit gutSrc;
+
+          sconsFlags = (drv.sconsFlags or "")
+                     + " system_certs_path=/etc/ssl/certs/ca-certificates.crt";
+
+          postPatch = (drv.postPatch or "") + ''
+            # Use system certs if user did not override project settings.
+            #
+            # This essentially implements the patch from OpenSUSE at
+            # https://bit.ly/2SKeYfi but without conflicts.
+            #
+            # The issue is tracked upstream at:
+            # https://github.com/godotengine/godot/issues/22232
+            sed -i -e '/^#include/ {
+              a #include <string.h>
+              :l; n
+              /#ifdef BUILTIN_CERTS_ENABLED/ {
+                i else if (strcmp(_SYSTEM_CERTS_PATH, "") != 0) \
+                  default_certs->load(_SYSTEM_CERTS_PATH);
+              }
+              bl
+            }' modules/mbedtls/crypto_mbedtls.cpp
+
+            # Godot only has a single base path, where all resources are loaded
+            # from. We could just copy over Gut into the source tree, but this
+            # would also mean that we need to keep it updated and prevent
+            # people from staging it in Git.
+            #
+            # Fortunately, there is an undocumented way to do path remapping,
+            # but it relies on the path_remap/remapped_paths setting for the
+            # project.
+            #
+            # So instead, we just patch the function that is responsible for
+            # loading the path remaps and inject all files from Gat.
+            find "$gutSrc" -path '*/addons/gut/*' \
+              -printf 'path_remaps["res://%P"] = "%p";\n' \
+              > core/io/path-remaps.h
+
+            sed -i -e '/ResourceLoader::load_path_remaps.*{/ {
+              a #include "path-remaps.h"
+            }' core/io/resource_loader.cpp
+          '';
+        });
+      in pkgs.writeScriptBin "godot-gut" ''
+        #!${pkgs.stdenv.shell}
+        exec ${godotGut}/bin/${godotCmd} --path "$PWD" \
+          -s "${gutSrc}/addons/gut/gut_cmdln.gd" "$@"
+      '';
+
+    in {
+      godot-gut = mkGodotGut false;
+      godot-gut-headless = mkGodotGut true;
+
+      godot-trello-reporting = pkgs.writeScriptBin "godot-trello-reporting" ''
+        #!${pkgs.stdenv.shell}
+        exec ${pkgs.godot}/bin/godot \
+          ${lib.escapeShellArg "${self}/Trello_Reporting_Tool.tscn"} \
+          "$@"
+      '';
+    });
+
+    checks = lib.genAttrs systems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (self.packages.${system}) godot-gut-headless;
+
+      testRunner = pkgs.writeScriptBin "test-runner" ''
+        #!${pkgs.stdenv.shell} -e
+        cd ${lib.escapeShellArg self}
+        exec ${godot-gut-headless}/bin/godot-gut -gtest=res://test.gd -gexit
+      '';
+
+    in {
+      integration = import (nixpkgs + "/nixos/tests/make-test-python.nix") {
+        name = "godot-trello-reporting";
+
+        nodes = {
+          client.environment.systemPackages = lib.singleton testRunner;
+        };
+
+        testScript = ''
+          # fmt: off
+          client.wait_for_unit('multi-user.target')
+          client.succeed('test-runner')
+        '';
+      } { inherit system; };
+    });
+
+    defaultPackage = let
+      getPackage = system: self.packages.${system}.godot-trello-reporting;
+    in lib.genAttrs systems getPackage;
+
+    devShell = lib.genAttrs systems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in pkgs.mkShell {
+      nativeBuildInputs = [ pkgs.godot self.packages.${system}.godot-gut ];
+    });
+  };
+}

--- a/minitrello.py
+++ b/minitrello.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p python3Packages.flask -p python3 -i python --argstr # noqa
+import re
+from hashlib import sha256
+from mmap import mmap, PROT_READ
+from uuid import uuid4
+from datetime import date as date_, datetime
+from functools import wraps
+from typing import cast, Callable, TypeVar, Any, Optional, \
+                   Dict, NamedTuple, List
+from flask import Flask, request, jsonify
+
+T = TypeVar('T')
+app = Flask('Trello')
+
+
+class Card(NamedTuple):
+    id: str
+    address: Optional[str] = None
+    badges: Any = {}
+    checkItemStates: List[str] = []
+    closed: bool = False
+    coordinates: Optional[str] = None
+    creationMethod: Optional[str] = None
+    dateLastActivity: datetime = datetime.now()
+    desc: str = ''
+    descData: Any = {}
+    due: Optional[datetime] = None
+    dueReminder: Optional[str] = None
+    email: str = ''
+    idBoard: str = ''
+    idChecklists: List[str] = []
+    idLabels: List[str] = []
+    idList: str = ''
+    idMembers: List[str] = []
+    idMembersVoted: List[str] = []
+    idShort: int = 0
+    idAttachmentCover: str = ''
+    labels: List[str] = []
+    limits: Any = {}
+    locationName: Optional[str] = None
+    manualCoverAttachment: bool = False
+    name: str = ''
+    pos: float = 0.0
+    shortLink: str = ''
+    shortUrl: str = ''
+    subscribed: bool = False
+    url: str = ''
+    cover: Any = {}
+
+
+class Attachment(NamedTuple):
+    id: str
+    bytes: Optional[str] = None
+    date: date_ = date_.today()
+    edgeColor: Optional[str] = None
+    idMember: str = ''
+    isUpload: bool = False
+    mimeType: str = ''
+    name: str = ''
+    previews: List[str] = []
+    url: str = ''
+    pos: int = 0
+
+
+def is_valid_arg(name, regex):
+    val = request.values.get(name)
+    return val is not None and re.match(regex, val) is not None
+
+
+def trello_api_call(f: Callable[..., T]) -> Callable[..., T]:
+    @wraps(f)
+    def _validate_api_call(*args: Any, **kwargs: Any) -> T:
+        if is_valid_arg('key', '^[0-9a-fA-F]{32}$') and \
+           is_valid_arg('token', '^[0-9a-fA-F]{64}$'):
+            return f(*args, **kwargs)
+        return app.make_response(('invalid key', 401))
+    return _validate_api_call
+
+
+trello_lists: Dict[str, List[Card]] = {}
+trello_attachments: Dict[str, List[Attachment]] = {}
+
+
+@app.route('/1/cards', methods=['POST'])
+@trello_api_call
+def create_card() -> Any:
+    idlist = request.values.get('idList')
+    if idlist is None:
+        return app.make_response(('idList required', 400))
+
+    if not is_valid_arg('idList', '^[0-9a-fA-F]{32}$'):
+        return app.make_response(('invalid idList value', 400))
+
+    if idlist not in trello_lists:
+        trello_lists[idlist] = []
+
+    pos = request.values.get('pos', 'bottom')
+    if pos == 'bottom':
+        highest = max(trello_lists[idlist], default=None, key=lambda c: c.pos)
+        newpos = 1000.0 if highest is None else highest.pos + 1.0
+    elif pos == 'top':
+        lowest = min(trello_lists[idlist], default=None, key=lambda c: c.pos)
+        newpos = 10.0 if lowest is None else lowest.pos / 2.0
+    else:
+        newpos = float(pos)
+
+    trello_lists[idlist].append(Card(
+        uuid4().hex,
+        pos=newpos,
+        address=request.values.get('address'),
+        coordinates=request.values.get('coordinates'),
+        desc=request.values.get('desc', ''),
+        due=request.values.get('due'),
+        dueReminder=request.values.get('dueComplete'),
+        idLabels=request.values.get('idLabels', []),
+        idMembers=request.values.get('idMembers', []),
+        locationName=request.values.get('locationName'),
+        name=request.values.get('name', ''),
+        url=request.values.get('urlSource', ''),
+    ))
+
+    trello_lists[idlist].sort(key=lambda c: c.pos)
+
+    return 'OK'
+
+
+@app.route('/1/cards/<cardid>/idLabels', methods=['POST'])
+@trello_api_call
+def add_label(cardid: str) -> Any:
+    if re.match('^[0-9a-fA-F]{32}$', cardid) is None:
+        return app.make_response(('invalid cardid value', 400))
+
+    newlabel = request.values.get('value')
+    if newlabel is not None:
+        for cards in trello_lists.values():
+            for card in cards:
+                if card.id == cardid.lower():
+                    card.idLabels.append(newlabel)
+    return 'OK'
+
+
+@app.route('/1/cards/<cardid>/attachments', methods=['POST'])
+@trello_api_call
+def add_attachment(cardid: str) -> Any:
+    if re.match('^[0-9a-fA-F]{32}$', cardid) is None:
+        return app.make_response(('invalid cardid value', 400))
+
+    mimetype = ''
+    filename = ''
+    if 'file' in request.files:
+        reqfile = request.files['file']
+        with mmap(reqfile.fileno(), 0, prot=PROT_READ) as data:
+            chksum = sha256(cast(bytes, data)).hexdigest()
+        mimetype = reqfile.mimetype
+        filename = reqfile.filename
+
+    if cardid not in trello_attachments:
+        trello_attachments[cardid] = []
+
+    pos = len(trello_attachments[cardid])
+
+    trello_attachments[cardid].append(Attachment(
+        uuid4().hex,
+        bytes=chksum,
+        pos=pos,
+        mimeType=request.values.get('mimeType', mimetype),
+        name=request.values.get('name', filename),
+    ))
+
+    return 'OK'
+
+
+@app.route('/1/lists/<listid>/cards', methods=['GET'])
+@trello_api_call
+def list_cards(listid: str) -> Any:
+    return jsonify([c._asdict() for c in trello_lists.get(listid, [])])
+
+
+@app.route('/__get_state', methods=['GET'])
+def get_state() -> Any:
+
+    return jsonify({
+        'lists': {
+            listid: list(map(lambda a: a._asdict(), cards))
+            for listid, cards in trello_lists.items()
+        },
+        'attachments': {
+            cardid: list(map(lambda a: a._asdict(), attachments))
+            for cardid, attachments in trello_attachments.items()
+        },
+    })
+
+
+if __name__ == '__main__':
+    app.run()

--- a/proxy.php
+++ b/proxy.php
@@ -36,7 +36,7 @@ if (empty($_POST['name']) || empty($_POST['desc'])) {
 
 $label_id = $_POST['label_id'] ?? null;
 
-if ($label_id !== null && !preg_match('/^[0-9a-fA-F]{32}$/', $label_id)) {
+if ($label_id !== null && !preg_match('/^[0-9a-fA-F]{24}$/', $label_id)) {
     http_response_code(400);
     exit('invalid label_id');
 }
@@ -133,7 +133,7 @@ if ($card_id === null) {
     exit('unable to find card with identifier '.$identifier);
 }
 
-if (!preg_match('/^[0-9a-fA-F]{32}$/', $card_id)) {
+if (!preg_match('/^[0-9a-fA-F]{24}$/', $card_id)) {
     http_response_code(502);
     curl_close($ch);
     exit('unable to find valid card_id with identifier '.$identifier);

--- a/proxy.php
+++ b/proxy.php
@@ -23,15 +23,77 @@ const TRELLO_LIST_ID = '@YOUR_TRELLO_LIST_ID@';
  *   name:        The name of the Trello card.
  *   desc:        The Markdown text of the card.
  *   label_id:    An optional label to attach to the card.
- *   cover_file:  The file form field indicating which file should be used as
- *                the cover.
- *   $name:       Any field $name which contains a valid file is added as an
- *                attachment to the card.
+ *   cover:       An optional image file to be used as the cover of the card.
+ *   attachments: A list of files to attach to the card.
  */
+
+/**
+ * Convert a given file upload into a CURLFile for submission with curl_exec()
+ *
+ * This is basically just a helper to validate the file upload and it stops
+ * execution of the script if there are any errors, so the value returned will
+ * *always* be valid.
+ *
+ * @param $file          The file array to handle coming from $_FILES
+ * @param $image_only    Whether to only allow images
+ * @param $allow_unknown Whether to trust the MIME type provided by uploader
+ */
+function upload2curl(
+    array &$file,
+    bool $image_only = false,
+    bool $allow_unknown = false
+): CURLFile {
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        exit('upload of attachment '.$file['name'].' failed');
+    }
+
+    if (!is_uploaded_file($file['tmp_name'])) {
+        http_response_code(400);
+        exit('refused possible file upload attack for '.$file['name']);
+    }
+
+    if ($allow_unknown) {
+        $filetype = $file['type'];
+    } else {
+        $filetype = mime_content_type($file['tmp_name']);
+    }
+
+    if ($image_only) {
+        switch ($filetype) {
+            case 'image/png':  $suffix = 'png'; break;
+            case 'image/jpeg': $suffix = 'jpg'; break;
+            case 'image/gif':  $suffix = 'gif'; break;
+            default:
+                http_response_code(403);
+                exit('type '.$filetype.' is not allowed for '.$file['name']);
+        }
+    } else {
+        $suffix = pathinfo($file['name'])['extension'] ?? null;
+    }
+
+    if ($file['type'] !== $filetype) {
+        http_response_code(400);
+        exit('wrong type '.$filetype.' for '.$file['name']);
+    }
+
+    $name = $file['name'];
+
+    if (!preg_match('/^[a-zA-Z0-9][a-zA-Z0-9_-]*\\.[a-zA-Z0-9]+$/', $name)) {
+        $name = uniqid().($suffix !== null ? '.'.$suffix : '');
+    }
+
+    return curl_file_create($file['tmp_name'], $file['type'], $name);
+}
 
 if (empty($_POST['name']) || empty($_POST['desc'])) {
     http_response_code(400);
     exit('insufficient data');
+}
+
+if (!is_string($_POST['name']) || !is_string($_POST['desc'])) {
+    http_response_code(400);
+    exit('invalid types used in submitted data');
 }
 
 $label_id = $_POST['label_id'] ?? null;
@@ -42,41 +104,31 @@ if ($label_id !== null && !preg_match('/^[0-9a-fA-F]{24}$/', $label_id)) {
 }
 
 $identifier = uniqid();
-$name = $_POST['name'].' ['.$identifier.']';
-$desc = $_POST['desc'];
+$card_name = $_POST['name'].' ['.$identifier.']';
+$card_desc = $_POST['desc'];
+
+$cover = null;
+if (is_array($_FILES['cover'] ?? null)) {
+    $cover = upload2curl($_FILES['cover'], true);
+}
 
 $attachments = [];
 
-foreach ($_FILES as $file) {
-    if ($file['error'] !== UPLOAD_ERR_OK) {
-        http_response_code(400);
-        exit('upload of attachment failed');
-    }
+if (is_array($_FILES['attachments'] ?? null)) {
+    if (is_array($_FILES['attachments']['name'])) {
+        foreach ($_FILES['attachments']['name'] as $index => $name) {
+            $file = [
+                'name' => $name,
+                'type' => $_FILES['attachments']['type'][$index],
+                'error' => $_FILES['attachments']['error'][$index],
+                'tmp_name' => $_FILES['attachments']['tmp_name'][$index],
+            ];
 
-    if (!is_uploaded_file($file['tmp_name'])) {
-        http_response_code(400);
-        exit('upload of '.$file['name'].' failed');
+            $attachments[] = upload2curl($file);
+        }
+    } else {
+        $attachments[] = upload2curl($_FILES['attachments']);
     }
-
-    switch ($content_type = mime_content_type($file['tmp_name'])) {
-        case 'image/png':
-        case 'image/jpeg':
-        case 'image/gif':
-            if ($file['type'] !== $content_type) {
-                http_response_code(400);
-                exit('wrong type '.$content_type.' for '.$file['name']);
-            }
-            break;
-        default:
-            http_response_code(403);
-            exit('mime type '.$content_type.' is not allowed');
-    }
-
-    $attachments['Image-'.$identifier] = curl_file_create(
-        $file['tmp_name'],
-        $file['type'],
-        $file['name']
-    );
 }
 
 $ch = curl_init();
@@ -89,8 +141,8 @@ curl_setopt($ch, CURLOPT_POSTFIELDS, [
     'token' => TRELLO_TOKEN,
     'key' => TRELLO_KEY,
     'idList' => TRELLO_LIST_ID,
-    'name' => $name,
-    'desc' => $desc,
+    'name' => $card_name,
+    'desc' => $card_desc,
     'pos' => 'top',
 ]);
 
@@ -126,23 +178,36 @@ if ($label_id !== null) {
     }
 }
 
-foreach ($attachments as $name => $file) {
-    $url = 'https://api.trello.com/1/cards/'.$card_id.'/attachments';
-    $is_cover = $name === ($_POST['cover_file'] ?? null);
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_POST, true);
+$url = 'https://api.trello.com/1/cards/'.$card_id.'/attachments';
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_POST, true);
+
+if ($cover !== null) {
     curl_setopt($ch, CURLOPT_POSTFIELDS, [
         'token' => TRELLO_TOKEN,
         'key' => TRELLO_KEY,
-        'name' => $name,
-        'setCover' => $is_cover,
+        'setCover' => true,
+        'file' => $cover,
+    ]);
+
+    if (curl_exec($ch) === false) {
+        http_response_code(502);
+        curl_close($ch);
+        exit('unable to add cover to card');
+    }
+}
+
+foreach ($attachments as $idx => $file) {
+    curl_setopt($ch, CURLOPT_POSTFIELDS, [
+        'token' => TRELLO_TOKEN,
+        'key' => TRELLO_KEY,
         'file' => $file,
     ]);
 
     if (curl_exec($ch) === false) {
         http_response_code(502);
         curl_close($ch);
-        exit('unable to attach file '.$name.' to card');
+        exit('unable to upload attachment '.($idx + 1).' to card');
     }
 }
 

--- a/proxy.php
+++ b/proxy.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types=1);
+
+/*
+ * You need to get a key and generate a token by visiting this website (And you
+ * need to be logged in with the correct account):
+ *
+ * https://trello.com/app-key
+ */
+const TRELLO_KEY = '@YOUR_TRELLO_API_KEY@';
+const TRELLO_TOKEN = '@YOUR_TRELLO_API_TOKEN@';
+
+/*
+ * To find the trello list id, the easiest way is to look up your Trello board,
+ * create the list you want to use, add a card, click on the card and add
+ * ".json" to the url in the top you can then search for idList" - string
+ * behind that is the list_id below.
+ */
+const TRELLO_LIST_ID = '@YOUR_TRELLO_LIST_ID@';
+
+/*
+ * POST values accepted:
+ *
+ *   name:        The name of the Trello card.
+ *   desc:        The Markdown text of the card.
+ *   label_id:    An optional label to attach to the card.
+ *   cover_file:  The file form field indicating which file should be used as
+ *                the cover.
+ *   $name:       Any field $name which contains a valid file is added as an
+ *                attachment to the card.
+ */
+
+if (empty($_POST['name']) || empty($_POST['desc'])) {
+    http_response_code(400);
+    exit('insufficient data');
+}
+
+$label_id = $_POST['label_id'] ?? null;
+
+if ($label_id !== null && !preg_match('/^[0-9a-fA-F]{32}$/', $label_id)) {
+    http_response_code(400);
+    exit('invalid label_id');
+}
+
+$identifier = uniqid();
+$name = $_POST['name'].' ['.$identifier.']';
+$desc = $_POST['desc'];
+
+$attachments = [];
+
+foreach ($_FILES as $file) {
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        exit('upload of attachment failed');
+    }
+
+    if (!is_uploaded_file($file['tmp_name'])) {
+        http_response_code(400);
+        exit('upload of '.$file['name'].' failed');
+    }
+
+    switch ($content_type = mime_content_type($file['tmp_name'])) {
+        case 'image/png':
+        case 'image/jpeg':
+        case 'image/gif':
+            if ($file['type'] !== $content_type) {
+                http_response_code(400);
+                exit('wrong type '.$content_type.' for '.$file['name']);
+            }
+            break;
+        default:
+            http_response_code(403);
+            exit('mime type '.$content_type.' is not allowed');
+    }
+
+    $attachments['Image-'.$identifier] = curl_file_create(
+        $file['tmp_name'],
+        $file['type'],
+        $file['name']
+    );
+}
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.trello.com/1/cards');
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_FAILONERROR, true);
+
+curl_setopt($ch, CURLOPT_POSTFIELDS, [
+    'token' => TRELLO_TOKEN,
+    'key' => TRELLO_KEY,
+    'idList' => TRELLO_LIST_ID,
+    'name' => $name,
+    'desc' => $desc,
+    'pos' => 'top',
+]);
+
+if (curl_exec($ch) === false) {
+    http_response_code(502);
+    curl_close($ch);
+    exit('unable to create card');
+}
+
+$url = 'https://api.trello.com/1/lists/'.TRELLO_LIST_ID.'/cards';
+curl_setopt($ch, CURLOPT_URL, $url.'?'.http_build_query([
+    'token' => TRELLO_TOKEN,
+    'key' => TRELLO_KEY,
+]));
+curl_setopt($ch, CURLOPT_HTTPGET, true);
+
+if (($response = curl_exec($ch)) === false) {
+    http_response_code(502);
+    curl_close($ch);
+    exit('unable to determine card ID');
+}
+
+if (($cards = json_decode($response, true)) === null) {
+    http_response_code(502);
+    curl_close($ch);
+    exit('unable to decode card ID');
+}
+
+$card_id = null;
+
+foreach ($cards as $card) {
+    if (strpos($card['name'], $identifier) !== false) {
+        $card_id = $card['id'];
+    }
+}
+
+if ($card_id === null) {
+    http_response_code(502);
+    curl_close($ch);
+    exit('unable to find card with identifier '.$identifier);
+}
+
+if (!preg_match('/^[0-9a-fA-F]{32}$/', $card_id)) {
+    http_response_code(502);
+    curl_close($ch);
+    exit('unable to find valid card_id with identifier '.$identifier);
+}
+
+if ($label_id !== null) {
+    $url = 'https://api.trello.com/1/cards/'.$card_id.'/idLabels';
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, [
+        'token' => TRELLO_TOKEN,
+        'key' => TRELLO_KEY,
+        'value' => $label_id,
+    ]);
+
+    if (curl_exec($ch) === false) {
+        $msg = 'Unable to attach label '.$label_id.' to card '.$card_id.'.';
+        trigger_error($msg, E_USER_WARNING);
+    }
+}
+
+foreach ($attachments as $name => $file) {
+    $url = 'https://api.trello.com/1/cards/'.$card_id.'/attachments';
+    $is_cover = $name === ($_POST['cover_file'] ?? null);
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, [
+        'token' => TRELLO_TOKEN,
+        'key' => TRELLO_KEY,
+        'name' => $name,
+        'setCover' => $is_cover,
+        'file' => $file,
+    ]);
+
+    if (curl_exec($ch) === false) {
+        http_response_code(502);
+        curl_close($ch);
+        exit('unable to attach file '.$name.' to card');
+    }
+}
+
+http_response_code(200);
+exit('OK');

--- a/proxy.php
+++ b/proxy.php
@@ -103,10 +103,6 @@ if ($label_id !== null && !preg_match('/^[0-9a-fA-F]{24}$/', $label_id)) {
     exit('invalid label_id');
 }
 
-$identifier = uniqid();
-$card_name = $_POST['name'].' ['.$identifier.']';
-$card_desc = $_POST['desc'];
-
 $cover = null;
 if (is_array($_FILES['cover'] ?? null)) {
     $cover = upload2curl($_FILES['cover'], true);
@@ -141,8 +137,8 @@ curl_setopt($ch, CURLOPT_POSTFIELDS, [
     'token' => TRELLO_TOKEN,
     'key' => TRELLO_KEY,
     'idList' => TRELLO_LIST_ID,
-    'name' => $card_name,
-    'desc' => $card_desc,
+    'name' => $_POST['name'],
+    'desc' => $_POST['desc'],
     'pos' => 'top',
 ]);
 

--- a/test.gd
+++ b/test.gd
@@ -20,9 +20,9 @@ func test_simple() -> void:
     # XXX: Ideally the node would be properly parametrizable, so let's override
     #      the variables we need to be changed in the ugliest way possible:
     scene.trello_labels = {
-        0: {'label_trello_id': '7f657925d36b4ec9a3406d3a2979b338',
+        0: {'label_trello_id': '7f657925d36b4ec9a3406d3a',
             'label_description': 'Test label 1'},
-        1: {'label_trello_id': '89daa2cc49014f0d9c3526d32511c155',
+        1: {'label_trello_id': '89daa2cc49014f0d9c3526d3',
             'label_description': 'Test label 2'},
     }
 
@@ -43,7 +43,7 @@ func test_simple() -> void:
     assert_eq(feedback_node.text, expected)
 
     var state: Dictionary = yield(get_trello_state(), 'completed')
-    var list_id: String = '44b3a1b2db65488e8ba5a9dfba1dd9aa'
+    var list_id: String = '44b3a1b2db65488e8ba5a9df'
 
     assert_has(state, 'lists')
     assert_has(state['lists'], list_id)
@@ -68,8 +68,9 @@ func test_simple() -> void:
     assert_eq(state['attachments'][card.id].size(), 1)
     var attachment: Dictionary = state['attachments'][card.id][0]
 
+    assert_eq(attachment.bytes as int, 3305)
     assert_eq(
-        attachment.bytes,
+        attachment.chksum,
         # SHA-256 of icon.png:
         '2c160bfdb8d0423b958083202dc7b58d499cbef22f28d2a58626884378ce9b7f'
     )

--- a/test.gd
+++ b/test.gd
@@ -1,6 +1,7 @@
 extends "res://addons/gut/test.gd"
 
-const BASEPATH = 'Trello_Reporting_Tool/VBoxContainer/HBoxContainer/'
+const BASEPATH = 'Trello_Reporting_Tool/Content/Form/'
+const FEEDBACK_PATH = 'Trello_Reporting_Tool/Content/Feedback/feedback_label'
 
 func get_trello_state() -> Dictionary:
     var req = HTTPRequest.new()
@@ -15,7 +16,7 @@ func get_trello_state() -> Dictionary:
     return json.result
 
 func assert_feedback(expected: String) -> void:
-    assert_eq(get_node(BASEPATH + 'Custom/feedback').text, expected)
+    assert_eq(get_node(FEEDBACK_PATH).text, expected)
 
 func submit_report(title: String, body: String, label: int = -1) -> void:
     get_node(BASEPATH + 'ShortDescEdit').text = title
@@ -26,7 +27,7 @@ func submit_report(title: String, body: String, label: int = -1) -> void:
 
 func wait_for_feedback(expected: String) -> void:
     for timeout in range(60):
-        if get_node(BASEPATH + 'Custom/feedback').text == expected:
+        if get_node(FEEDBACK_PATH).text == expected:
             break
         yield(yield_for(1), YIELD)
 

--- a/test.gd
+++ b/test.gd
@@ -47,7 +47,7 @@ func before_each() -> void:
     add_child_autofree(scene)
 
 func test_simple() -> void:
-    submit_report('some report', 'some report text')
+    submit_report('some report \u2b52', 'some report text')
     assert_feedback('Your feedback is being sent...')
 
     yield(wait_for_feedback('Feedback sent successfully, thank you!'),
@@ -64,7 +64,7 @@ func test_simple() -> void:
     assert_eq(cards.size(), 1)
     var card: Dictionary = cards[0]
 
-    assert_eq(card['name'], 'some report')
+    assert_eq(card['name'], 'some report ⭒')
     assert_string_starts_with(card['desc'], 'some report text')
     assert_string_contains(card['desc'], 'Operating System:')
     assert_eq(card['pos'], 10.0)

--- a/test.gd
+++ b/test.gd
@@ -19,13 +19,6 @@ func test_simple() -> void:
 
     # XXX: Ideally the node would be properly parametrizable, so let's override
     #      the variables we need to be changed in the ugliest way possible:
-    scene.trello_key = '6686ab7c98c9478a858c7509cce4e567'
-    scene.trello_token = '903a96bcb0f2457986ed6f4e4d4d5016'\
-                       + '04ea488a45034e57aea56a16ed59528a'
-    scene.key_and_token = "?key=" + scene.trello_key \
-                        + "&token=" + scene.trello_token
-    scene.list_id = '44b3a1b2db65488e8ba5a9dfba1dd9aa'
-
     scene.trello_labels = {
         0: {'label_trello_id': '7f657925d36b4ec9a3406d3a2979b338',
             'label_description': 'Test label 1'},
@@ -50,12 +43,13 @@ func test_simple() -> void:
     assert_eq(feedback_node.text, expected)
 
     var state: Dictionary = yield(get_trello_state(), 'completed')
+    var list_id: String = '44b3a1b2db65488e8ba5a9dfba1dd9aa'
 
     assert_has(state, 'lists')
-    assert_has(state['lists'], scene.list_id)
+    assert_has(state['lists'], list_id)
 
-    assert_eq(state['lists'][scene.list_id].size(), 1)
-    var cards: Array = state['lists'][scene.list_id]
+    assert_eq(state['lists'][list_id].size(), 1)
+    var cards: Array = state['lists'][list_id]
     assert_eq(cards.size(), 1)
     var card: Dictionary = cards[0]
 

--- a/test.gd
+++ b/test.gd
@@ -1,0 +1,22 @@
+extends "res://addons/gut/test.gd"
+
+func test_simple() -> void:
+    var scene = load('res://Trello_Reporting_Tool.tscn').instance()
+    var basepath = 'Trello_Reporting_Tool/VBoxContainer/HBoxContainer/'
+    add_child_autofree(scene)
+
+    get_node(basepath + 'ShortDescEdit').text = 'some report'
+    get_node(basepath + 'LongDescEdit').text = 'some report text'
+    get_node(basepath + 'Custom/Send').emit_signal('pressed')
+
+    var feedback_node = get_node(basepath + 'Custom/feedback')
+
+    assert_eq(feedback_node.text, 'Your feedback is being sent...')
+
+    var expected = 'Feedback sent successfully, thank you!'
+    for timeout in range(60):
+        if feedback_node.text == expected:
+            break
+        yield(yield_for(1), YIELD)
+
+    assert_eq(feedback_node.text, expected)

--- a/test.gd
+++ b/test.gd
@@ -76,18 +76,29 @@ func test_simple() -> void:
 
     assert_has(state, 'attachments')
     assert_has(state['attachments'], card.id)
-    assert_eq(state['attachments'][card.id].size(), 1)
-    var attachment: Dictionary = state['attachments'][card.id][0]
+    assert_eq(state['attachments'][card.id].size(), 3)
 
-    assert_eq(attachment.bytes as int, 3305)
-    assert_eq(
-        attachment.chksum,
-        # SHA-256 of icon.png:
-        '2c160bfdb8d0423b958083202dc7b58d499cbef22f28d2a58626884378ce9b7f'
-    )
+    var names = []
 
-    assert_eq(attachment.name, 'Image-' + identifier)
-    assert_eq(attachment.mimeType, 'image/png')
+    for attachment in state['attachments'][card.id]:
+        names.push_back(attachment['name'])
+
+        match attachment['name']:
+            'icon.png':
+                assert_eq(attachment['bytes'] as int, 3305)
+                assert_eq(
+                    attachment['chksum'],
+                    # SHA-256 of icon.png:
+                    '2c160bfdb8d0423b958083202dc7b58d' +
+                    '499cbef22f28d2a58626884378ce9b7f'
+                )
+                assert_eq(attachment['mimeType'], 'image/png')
+            _:
+                assert_gt(attachment['bytes'] as int, 0)
+                assert_eq(attachment['mimeType'], 'image/png')
+
+    names.sort()
+    assert_eq(names, ['icon.png', 'noise1.png', 'noise2.png'])
 
 func test_empty_title() -> void:
     submit_report('', 'non-empty')

--- a/test.gd
+++ b/test.gd
@@ -1,9 +1,37 @@
 extends "res://addons/gut/test.gd"
 
+func get_trello_state() -> Dictionary:
+    var req = HTTPRequest.new()
+    add_child_autoqfree(req)
+
+    var url = 'https://api.trello.com/__get_state'
+    req.request(url, [], true, HTTPClient.METHOD_GET)
+
+    var response = yield(req, 'request_completed')
+    var json = JSON.parse(response[3].get_string_from_utf8())
+    assert_eq(json.error, OK)
+    return json.result
+
 func test_simple() -> void:
     var scene = load('res://Trello_Reporting_Tool.tscn').instance()
     var basepath = 'Trello_Reporting_Tool/VBoxContainer/HBoxContainer/'
     add_child_autofree(scene)
+
+    # XXX: Ideally the node would be properly parametrizable, so let's override
+    #      the variables we need to be changed in the ugliest way possible:
+    scene.trello_key = '6686ab7c98c9478a858c7509cce4e567'
+    scene.trello_token = '903a96bcb0f2457986ed6f4e4d4d5016'\
+                       + '04ea488a45034e57aea56a16ed59528a'
+    scene.key_and_token = "?key=" + scene.trello_key \
+                        + "&token=" + scene.trello_token
+    scene.list_id = '44b3a1b2db65488e8ba5a9dfba1dd9aa'
+
+    scene.trello_labels = {
+        0: {'label_trello_id': '7f657925d36b4ec9a3406d3a2979b338',
+            'label_description': 'Test label 1'},
+        1: {'label_trello_id': '89daa2cc49014f0d9c3526d32511c155',
+            'label_description': 'Test label 2'},
+    }
 
     get_node(basepath + 'ShortDescEdit').text = 'some report'
     get_node(basepath + 'LongDescEdit').text = 'some report text'
@@ -20,3 +48,37 @@ func test_simple() -> void:
         yield(yield_for(1), YIELD)
 
     assert_eq(feedback_node.text, expected)
+
+    var state: Dictionary = yield(get_trello_state(), 'completed')
+
+    assert_has(state, 'lists')
+    assert_has(state['lists'], scene.list_id)
+
+    assert_eq(state['lists'][scene.list_id].size(), 1)
+    var cards: Array = state['lists'][scene.list_id]
+    assert_eq(cards.size(), 1)
+    var card: Dictionary = cards[0]
+
+    var regex = RegEx.new()
+    assert_eq(regex.compile('^some report \\[([^]]+)\\]$'), OK)
+    var re_match = regex.search(card['name'])
+    assert_not_null(re_match)
+    var identifier: String = re_match.get_string(1)
+
+    assert_string_starts_with(card['desc'], 'some report text')
+    assert_string_contains(card['desc'], 'Operating System:')
+    assert_eq(card['pos'], 10.0)
+
+    assert_has(state, 'attachments')
+    assert_has(state['attachments'], card.id)
+    assert_eq(state['attachments'][card.id].size(), 1)
+    var attachment: Dictionary = state['attachments'][card.id][0]
+
+    assert_eq(
+        attachment.bytes,
+        # SHA-256 of icon.png:
+        '2c160bfdb8d0423b958083202dc7b58d499cbef22f28d2a58626884378ce9b7f'
+    )
+
+    assert_eq(attachment.name, 'Image-' + identifier)
+    assert_eq(attachment.mimeType, 'image/png')

--- a/test.gd
+++ b/test.gd
@@ -64,12 +64,7 @@ func test_simple() -> void:
     assert_eq(cards.size(), 1)
     var card: Dictionary = cards[0]
 
-    var regex = RegEx.new()
-    assert_eq(regex.compile('^some report \\[([^]]+)\\]$'), OK)
-    var re_match = regex.search(card['name'])
-    assert_not_null(re_match)
-    var identifier: String = re_match.get_string(1)
-
+    assert_eq(card['name'], 'some report')
     assert_string_starts_with(card['desc'], 'some report text')
     assert_string_contains(card['desc'], 'Operating System:')
     assert_eq(card['pos'], 10.0)


### PR DESCRIPTION
Embedding the Trello API token and key is not a very good idea if you don't want to compromise your account. Even if you're using a dedicated account just for submitting cards, the main Trello account is unaffected but attackers can still trash the account and ultimately break reporting for other users.

This is solved by adding an intermediate proxy as the only instance holding the Trello API token and key, which accepts a single request from the Godot reporting tool and submits multiple requests to the Trello API in the same way we had so far in the Godot implementation.

Since writing the proxy took only a few minutes it took several hours of fighting against GDScript, so having *less* complexity in the GDScript part is certainly a plus :sweat_smile:

The proxy is implemented in PHP because it's the most widespread language in shared hosting environments.

Note that the proxy currently doesn't have any added authentication and/or rate limiting/throttling, so the sole knowledge of the URL is enough to submit cards. However, this shouldn't result in any *added* attack surface, since an attacker with knowledge about authentication information (again - which can be extracted from the Godot project) can submit cards in exactly the same way anyway.

Another thing that took a while to implement was the integration test, since Godot acts differently in headless environments and it also refuses running with eg. Xvfb. Since we need to have networking in our test environment anyway, I went with NixOS VM tests for that. Unfortunately, running those tests on Windows or even GitHub Actions will need nested virtualisation, which unfortunately [isn't supported](https://github.com/actions/virtual-environments/issues/183).

Fortunately, someone™ is running a public Hydra instance, which should [take care of CI](https://headcounter.org/hydra/jobset/picster/godot-trello).