### PR TITLE
Fix logo image SHA-256 and size in test

### DIFF
--- a/tests/integration.gd
+++ b/tests/integration.gd
@@ -81,12 +81,12 @@ func test_simple() -> void:
 
         match attachment['name']:
             'icon.png':
-                assert_eq(attachment['bytes'] as int, 3305)
+                assert_eq(attachment['bytes'] as int, 11938)
                 assert_eq(
                     attachment['chksum'],
                     # SHA-256 of icon.png:
-                    '2c160bfdb8d0423b958083202dc7b58d' +
-                    '499cbef22f28d2a58626884378ce9b7f'
+                    '2cb95be3137bf3d77f6626ee5f3ac79b' +
+                    '38eff5ac3142512191c0ba1dfae73f5d'
                 )
                 assert_eq(attachment['mimeType'], 'image/png')
             _:


### PR DESCRIPTION
Test failure introduced in 556f7be7b60ceec762193b35c44bda372d7caf27.

The commit in question has changed the logo image and since the SHA-256 and size of the image is verified in the integration test, the test subsequently fails.

A better way to solve this would be if we'd have a way to properly parameterise the main functionality instead of expecting users to change source files. This could probably involve turning the project into a proper Godot plugin, which I outlined in #2.

For now however, I don't have a lot of time to allocate to dig into Godot plugins, so I'm simply fixing the SHA-256 and size.